### PR TITLE
Update resources

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -24,7 +24,7 @@ if (APPLE)
    INSTALL(FILES "${RESOURCEDIR}/GrandOrgue.icns" DESTINATION "${RESOURCEINSTDIR}")
    LIST(APPEND DEPLIST "${RESOURCEDIR}/GrandOrgue.icns")
 elseif(UNIX)
-  install(FILES GrandOrgue.png DESTINATION share/pixmaps)
+  install(FILES GrandOrgue.png DESTINATION share/icons/hicolor/32x32/apps)
   install(FILES grandorgue.xml DESTINATION share/mime/packages)
 
   if (GETTEXT_FOUND)

--- a/resources/GrandOrgue.appdata.xml
+++ b/resources/GrandOrgue.appdata.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  GrandOrgue - free pipe organ simulator
- 
+
  Copyright 2006 Milan Digital Audio LLC
- Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
- 
+ Copyright 2009-2021 GrandOrgue contributors (see AUTHORS)
+
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License as
  published by the Free Software Foundation; either version 2 of the
  License, or (at your option) any later version.
- 
+
  This program is distributed in the hope that it will be useful, but
  WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with this program; if not, write to the Free Software
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -23,24 +23,48 @@
  Creative Commons Attribution-ShareAlike 3.0 license, 
  http://creativecommons.org/licenses/by-sa/3.0
 -->
-<application>
- <id type="desktop">GrandOrgue.desktop</id>
- <metadata_license>CC BY-SA</metadata_license>
- <project_license>GPL-2.0+</project_license>
- <name>GrandOrgue</name>
- <summary>Pipe organ simulator</summary>
- <description>
-  <p>
- GrandOrgue is a virtual pipe organ sample player application supporting
- a HW1 compatible file format.
-  </p>
- </description>
- <screenshots>
-  <screenshot type="default" width="1015" height="751">https://sourceforge.net/p/ourorgan/screenshot/PiteaMHS_main.png</screenshot>
-  <screenshot width="960" height="643">https://sourceforge.net/p/ourorgan/screenshot/Burea_funeral_extend_main.jpg</screenshot>
-  <screenshot width="1051" height="751">https://sourceforge.net/p/ourorgan/screenshot/Burea_chuch_gui.png</screenshot>
-  <screenshot width="1271" height="751">https://sourceforge.net/p/ourorgan/screenshot/Burea_church_extended.png</screenshot>
- </screenshots>
- <url type="homepage">https://sourceforge.net/p/ourorgan/wiki/</url>
- <updatecontact>ourorgan-developers@lists.sourceforge.net</updatecontact>
-</application>
+<component type="desktop-application">
+  <id>net.sourceforge.GrandOrgue</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <name>GrandOrgue</name>
+  <summary>Pipe organ simulator</summary>
+  <url type="homepage">https://sourceforge.net/projects/ourorgan"</url>
+
+  <description>
+    <p>
+      GrandOrgue is a virtual pipe organ sample player application supporting
+      a HW1 compatible file format.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">net.sourceforge.GrandOrgue.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://sourceforge.net/p/ourorgan/screenshot/PiteaMHS_main.png</image>
+    </screenshot>
+
+    <screenshot>
+      <image>https://sourceforge.net/p/ourorgan/screenshot/Burea_funeral_extend_main.jpg</image>
+    </screenshot>
+
+    <screenshot>
+      <image>https://sourceforge.net/p/ourorgan/screenshot/Burea_chuch_gui.png</image>
+    </screenshot>
+
+    <screenshot>
+      <image>https://sourceforge.net/p/ourorgan/screenshot/Burea_church_extended.png</image>
+    </screenshot>
+  </screenshots>
+
+  <provides>
+    <binary>GrandOrgue</binary>
+  </provides>
+
+  <releases>
+    <release version="0.3.1.2338" date="2021-01-04"></release>
+  </releases>
+
+  <content_rating type="oars-1.1" />
+</component>


### PR DESCRIPTION
Update GrandOrgue resources:

* Fix default icon installation path (from obsolete `/usr/share/pixmaps` to XDG-compliant `/usr/share/icons/hicolor/32x32/apps`)
* Update AppData file according to new AppStream specification.