### PR TITLE
Fix some issues with pipewire

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ else()
 endif ()
 
 if (RTAUDIO_USE_JACK OR RTMIDI_USE_JACK OR GO_USE_JACK)
-  pkg_check_modules(JACK REQUIRED jack)
+  pkg_check_modules(JACK REQUIRED IMPORTED_TARGET jack)
 endif()
 
 # include RtAudio

--- a/build-scripts/for-linux/prepare-fedora.sh
+++ b/build-scripts/for-linux/prepare-fedora.sh
@@ -2,5 +2,5 @@
 
 set -e
 sudo dnf install -y cmake gcc-c++ make gettext docbook-style-xsl zip po4a \
-  jack-audio-connection-kit-devel fftw-devel zlib-devel wavpack-devel wxGTK3-devel \
+  pipewire-jack-audio-connection-kit-devel fftw-devel zlib-devel wavpack-devel wxGTK3-devel \
   alsa-lib-devel systemd-devel

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -194,5 +194,5 @@ add_custom_target(runperftest COMMAND perftest "${CMAKE_SOURCE_DIR}/tests" DEPEN
 
 if (GO_USE_JACK STREQUAL "ON")
    add_definitions(-DGO_USE_JACK)
-   target_link_libraries(GrandOrgue jack)
+   target_link_libraries(GrandOrgue PkgConfig::JACK)
 endif ()

--- a/src/grandorgue/GOrgueSoundJackPort.cpp
+++ b/src/grandorgue/GOrgueSoundJackPort.cpp
@@ -40,7 +40,7 @@ GOrgueSoundJackPort::~GOrgueSoundJackPort()
 
 static const wxString DEVICE_NAME = "Jack Output";
 static const jack_options_t JACK_OPTIONS = JackNullOption;
-static const char * CLIENT_NAME = "GrandOrgue";
+static const char * CLIENT_NAME = "GrandOrgueOut";
 
 void GOrgueSoundJackPort::JackLatencyCallback (jack_latency_callback_mode_t mode, void *data) {
 	if (mode == JackPlaybackLatency) {

--- a/src/grandorgue/GOrgueSoundJackPort.cpp
+++ b/src/grandorgue/GOrgueSoundJackPort.cpp
@@ -40,7 +40,7 @@ GOrgueSoundJackPort::~GOrgueSoundJackPort()
 
 static const wxString DEVICE_NAME = "Jack Output";
 static const jack_options_t JACK_OPTIONS = JackNullOption;
-static const char * CLIENT_NAME = "GrandOrgueOut";
+static const char * CLIENT_NAME = "GrandOrgueAudio";
 
 void GOrgueSoundJackPort::JackLatencyCallback (jack_latency_callback_mode_t mode, void *data) {
 	if (mode == JackPlaybackLatency) {

--- a/src/grandorgue/GOrgueSoundPortaudioPort.cpp
+++ b/src/grandorgue/GOrgueSoundPortaudioPort.cpp
@@ -94,7 +94,7 @@ wxString GOrgueSoundPortaudioPort::getName(unsigned index)
 {
 	const PaDeviceInfo* info = Pa_GetDeviceInfo(index);
 	const PaHostApiInfo *api = Pa_GetHostApiInfo(info->hostApi);
-	return wxGetTranslation(wxString::FromAscii(api->name)) + wxString(_(" (PA): ")) + wxString::FromAscii(info->name);
+	return wxGetTranslation(wxString::FromAscii(api->name)) + wxString(_(" (PA): ")) + wxString(info->name);
 }
 
 GOrgueSoundPort* GOrgueSoundPortaudioPort::create(GOrgueSound* sound, wxString name)

--- a/src/grandorgue/GOrgueSoundRtPort.cpp
+++ b/src/grandorgue/GOrgueSoundRtPort.cpp
@@ -169,7 +169,7 @@ wxString GOrgueSoundRtPort::getName(RtAudio::Api api, RtAudio* rt_api, unsigned 
 	try
 	{
 		RtAudio::DeviceInfo info = rt_api->getDeviceInfo(index);
-		return  prefix + wxString::FromAscii(info.name.c_str());
+		return  prefix + wxString(info.name);
 	}
 	catch (RtAudioError &e)
 	{

--- a/src/portaudio/CMakeLists.txt
+++ b/src/portaudio/CMakeLists.txt
@@ -58,6 +58,7 @@ set(PortAudio_Mac
   hostapi/coreaudio/pa_mac_core_blocking.c
   hostapi/coreaudio/pa_mac_core_utilities.c)
 
+set(PA_LIBDIRS)
 set(PA_Libs)
 
 if (WIN32)
@@ -109,7 +110,8 @@ if (WIN32)
    if (RTAUDIO_USE_JACK)
       add_definitions(-DPA_USE_JACK)
       set(PortAudio_Sources ${PortAudio_Sources} hostapi/jack/pa_jack.c)
-      set(PA_Libs ${PA_Libs} jack)
+      set(PA_LIBDIRS ${PA_LIBDIRS} ${JACK_LIBRARY_DIRS})
+      set(PA_Libs ${PA_Libs} ${JACK_LIBRARIES})
    endif ()
 
    set(PortAudio_Sources ${PortAudio_Sources} ${PortAudio_Win})
@@ -126,7 +128,8 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
    if (RTAUDIO_USE_JACK)
       add_definitions(-DPA_USE_JACK)
       set(PortAudio_Sources ${PortAudio_Sources} hostapi/jack/pa_jack.c)
-      set(PA_Libs ${PA_Libs} jack)
+      set(PA_LIBDIRS ${PA_LIBDIRS} ${JACK_LIBRARY_DIRS})
+      set(PA_Libs ${PA_Libs} ${JACK_LIBRARIES})
    endif ()
 
    if (RTAUDIO_USE_ALSA)
@@ -156,7 +159,8 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
    if (RTAUDIO_USE_JACK)
       add_definitions(-DPA_USE_JACK)
       set(PortAudio_Sources ${PortAudio_Sources} hostapi/jack/pa_jack.c)
-      set(PA_Libs ${PA_Libs} jack)
+      set(PA_LIBDIRS ${PA_LIBDIRS} ${JACK_LIBRARY_DIRS})
+      set(PA_Libs ${PA_Libs} ${JACK_LIBRARIES})
    endif ()
 
    if (RTAUDIO_USE_CORE)
@@ -174,6 +178,7 @@ endif ()
 include_directories(${JACK_INCLUDE_DIRS})
 
 add_library(PortAudio STATIC ${PortAudio_Sources})
+target_link_directories(PortAudio PUBLIC ${PA_LIBDIRS})
 target_link_libraries(PortAudio ${PA_Libs})
 
 message(STATUS "============================================================================")

--- a/src/rt/rtaudio/CMakeLists.txt
+++ b/src/rt/rtaudio/CMakeLists.txt
@@ -64,7 +64,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
    if (RTAUDIO_USE_JACK)
       add_definitions(-D__UNIX_JACK__)
-      target_link_libraries(RtAudio jack)
+      target_link_libraries(RtAudio PkgConfig::JACK)
    endif ()
 
    if (RTAUDIO_USE_ALSA)
@@ -87,7 +87,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
    if (RTAUDIO_USE_JACK)
       add_definitions(-D__UNIX_JACK__)
-      target_link_libraries(RtAudio jack)
+      target_link_libraries(RtAudio PkgConfig::JACK)
    endif ()
 
    if (RTAUDIO_USE_CORE)

--- a/src/rt/rtmidi/CMakeLists.txt
+++ b/src/rt/rtmidi/CMakeLists.txt
@@ -32,7 +32,7 @@ if (WIN32)
 
    if (RTMIDI_USE_JACK)
       add_definitions(-D__UNIX_JACK__)
-      target_link_libraries(RtMidi jack)
+      target_link_libraries(RtMidi PkgConfig::JACK)
    endif ()
 
    if (RTMIDI_USE_MM)
@@ -48,7 +48,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
    if (RTMIDI_USE_JACK)
       add_definitions(-D__UNIX_JACK__)
-      target_link_libraries(RtMidi jack)
+      target_link_libraries(RtMidi PkgConfig::JACK)
    endif ()
 
    if (RTMIDI_USE_ALSA)
@@ -69,7 +69,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
    if (RTMIDI_USE_JACK)
       add_definitions(-D__UNIX_JACK__)
-      target_link_libraries(RtMidi jack)
+      target_link_libraries(RtMidi PkgConfig::JACK)
    endif ()
 
    if (RTMIDI_USE_CORE)


### PR DESCRIPTION
- [x] Compiling on fedora34: use pipewire-jack-audio-connection-kit-devel instead of jack-audio-connection-kit-devel https://github.com/oleg68/GrandOrgue/commit/9ecf82c39d22572e4de853c08aa88454e20adff5
- [x] Wrong localised device names https://github.com/oleg68/GrandOrgue/commit/7e276f3bf5b05a4b9e2610400a039a151e37e11c
- [x] https://github.com/oleg68/GrandOrgue/issues/28 Jack native client name `GrandOrgue` -> `GrandOrgueAudio` https://github.com/oleg68/GrandOrgue/commit/6bb2a5bd4f767f3f46315288b3c5dd8c81957b39 https://github.com/oleg68/GrandOrgue/commit/7b56f0c0016e0be7ff2fee19c7fc1306aa471a30