### PR TITLE
Displaying actual error text instead of ``Internal Portaudio Error`` resolves #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Displaying actual error text instead of ``Internal Portaudio Error`` https://github.com/oleg68/GrandOrgue/issues/52
 - Added capability of disabling some sound ports and API's
 - Eliminated extra opening sound devices
 - Changed the sound device name format to ``Subsys: Api: Device`` https://github.com/oleg68/GrandOrgue/issues/48

--- a/src/grandorgue/GOrgueSoundPortaudioPort.h
+++ b/src/grandorgue/GOrgueSoundPortaudioPort.h
@@ -33,6 +33,7 @@ private:
 	static int Callback (const void *input, void *output, unsigned long frameCount, const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags, void *userData);
 
 	static wxString getName(unsigned index);
+	static wxString getLastError(PaError error);
 
 public:
 	static const wxString PORT_NAME;


### PR DESCRIPTION
Using Pa_GetLastHostErrorInfo for getting an actual error message on paInternalError.

This does not conform the specification https://github.com/PortAudio/portaudio/issues/620
