### PR TITLE
Fixed ``A device wants different samples per buffer: 15`` on OSx with RtAudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
+- Fixed ``A device wants different samples per buffer: 15`` on OSx  with RtAudio
 - Displaying actual error text instead of ``Internal Portaudio Error`` https://github.com/oleg68/GrandOrgue/issues/52
-- Added capability of disabling some sound ports and API's
-- Eliminated extra opening sound devices
+- Added capability of disabling some sound ports and API's https://github.com/oleg68/GrandOrgue/issues/48
+- Eliminated extra opening sound devices https://github.com/oleg68/GrandOrgue/issues/48
 - Changed the sound device name format to ``Subsys: Api: Device`` https://github.com/oleg68/GrandOrgue/issues/48
 # 0.3.1.2341-8.os (2021-07-26)
 - Moved Language selection on top of the first setting page

--- a/src/grandorgue/GOrgueSoundRtPort.cpp
+++ b/src/grandorgue/GOrgueSoundRtPort.cpp
@@ -69,7 +69,9 @@ void GOrgueSoundRtPort::Open()
 				aOutputParam.deviceId = i;
 
 		RtAudio::StreamOptions aOptions;
-		aOptions.flags = RTAUDIO_MINIMIZE_LATENCY;
+		// the next flag causes Rt/Core forces setting the buffer size to 15 
+		// and the sound distortion https://github.com/oleg68/GrandOrgue/issues/54
+		// aOptions.flags = RTAUDIO_MINIMIZE_LATENCY;
 		aOptions.numberOfBuffers = (m_Latency * m_SampleRate) / (m_SamplesPerBuffer * 1000);
 		aOptions.streamName = "GrandOrgue";
 


### PR DESCRIPTION
Using RTAUDIO_MINIMIZE_LATENCY flag when opening RtAudio/CoreAudio stream always set the SamplesPerBuffer to the minimum possible value 15