### PR TITLE
Fixing main window size issues and craching on OSx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on OSx when GrandOrgue was exiting https://github.com/oleg68/GrandOrgue/issues/68
 - Removed obsolete and unused files from the source code
 # 0.3.1.2341-12.os (2021-08-17)
 - Fixed ``error creating OS-X MIDI client object`` error messages on OSx

--- a/src/grandorgue/GOrgueDocument.cpp
+++ b/src/grandorgue/GOrgueDocument.cpp
@@ -30,6 +30,7 @@
 #include "GOrgueSound.h"
 #include "GOrgueView.h"
 #include "GrandOrgueFile.h"
+#include "GrandOrgueFrame.h"
 #include "GrandOrgueID.h"
 #include "MIDIEventDialog.h"
 #include "MIDIList.h"
@@ -104,7 +105,12 @@ bool GOrgueDocument::Import(GOrgueProgressDialog* dlg, const GOrgueOrgan& organ,
 		if (m_organfile->GetPanel(i)->InitialOpenWindow())
 			ShowPanel(i);
 	if (!m_organfile->GetMainWindowData()->GetWindowSize().IsEmpty())
-		wxTheApp->GetTopWindow()->SetSize(m_organfile->GetMainWindowData()->GetWindowSize());
+	{
+	  GOrgueFrame * const frame = dynamic_cast<GOrgueFrame *>(wxTheApp->GetTopWindow());
+	  
+	  if (frame)
+	    frame->ApplyRectFromSettings(m_organfile->GetMainWindowData()->GetWindowSize());
+	}
 
 	m_sound.AssignOrganFile(m_organfile);
 	m_OrganFileReady = true;

--- a/src/grandorgue/GOrgueSettings.cpp
+++ b/src/grandorgue/GOrgueSettings.cpp
@@ -508,6 +508,15 @@ void GOrgueSettings::SetAudioDeviceConfig(const std::vector<GOAudioDeviceConfig>
 	m_AudioDeviceConfig = config;
 }
 
+const unsigned GOrgueSettings::GetTotalAudioChannels() const
+{
+  unsigned channels = 0;
+  
+  for (const GOAudioDeviceConfig & deviceConfig: m_AudioDeviceConfig)
+    channels += deviceConfig.channels;
+  return channels;
+}
+
 unsigned GOrgueSettings::GetDefaultLatency()
 {
 	return 50;

--- a/src/grandorgue/GOrgueSettings.cpp
+++ b/src/grandorgue/GOrgueSettings.cpp
@@ -98,6 +98,10 @@ GOrgueSettings::GOrgueSettings(wxString instance) :
 	m_AudioGroups(),
 	m_AudioDeviceConfig(),
 	m_MIDIEvents(),
+	m_MainWindowX(0),
+	m_MainWindowY(0),
+	m_MainWindowWidth(0),
+	m_MainWindowHeight(0),
 	UserSettingPath(this, wxT("General"), wxT("SettingPath"), wxEmptyString),
 	UserCachePath(this, wxT("General"), wxT("CachePath"), wxEmptyString),
 	Concurrency(this, wxT("General"), wxT("Concurrency"), 0, MAX_CPU, 1),
@@ -189,6 +193,11 @@ void GOrgueSettings::Load()
 		GOrgueConfigReader cfg(cfg_db);
 
 		GOrgueOrganList::Load(cfg, m_MidiMap);
+		
+		m_MainWindowX = cfg.ReadInteger(CMBSetting, wxT("UI"), wxT("MainWindowX"), -32000, 32000, false, 0);
+		m_MainWindowY = cfg.ReadInteger(CMBSetting, wxT("UI"), wxT("MainWindowY"), -32000, 32000, false, 0);
+		m_MainWindowWidth = (unsigned) cfg.ReadInteger(CMBSetting, wxT("UI"), wxT("MainWindowWidth"), 0, 32000, false, 0);
+		m_MainWindowHeight = (unsigned) cfg.ReadInteger(CMBSetting, wxT("UI"), wxT("MainWindowHeight"), 0, 32000, false, 0);
 
 		m_Temperaments.InitTemperaments();
 		m_Temperaments.Load(cfg);
@@ -532,6 +541,19 @@ GOrgueTemperamentList& GOrgueSettings::GetTemperaments()
 	return m_Temperaments;
 }
 
+wxRect GOrgueSettings::GetMainWindowRect()
+{
+  return wxRect(m_MainWindowX, m_MainWindowY, m_MainWindowWidth, m_MainWindowHeight);
+}
+
+void GOrgueSettings::SetMainWindowRect(const wxRect &rect)
+{
+  m_MainWindowX = rect.x;
+  m_MainWindowY = rect.y;
+  m_MainWindowWidth = rect.width;
+  m_MainWindowHeight = rect.height;
+}
+
 void GOrgueSettings::Flush()
 {
 	wxString tmp_name = m_ConfigFileName + wxT(".new");
@@ -539,7 +561,12 @@ void GOrgueSettings::Flush()
 	GOrgueConfigWriter cfg(cfg_file, false);
 
 	GOrgueSettingStore::Save(cfg);
-	GOrgueOrganList::Save(cfg, m_MidiMap);
+	GOrgueOrganList::Save(cfg, m_MidiMap);;
+
+	cfg.WriteInteger(wxT("UI"), wxT("MainWindowX"), m_MainWindowX);
+	cfg.WriteInteger(wxT("UI"), wxT("MainWindowY"), m_MainWindowY);
+	cfg.WriteInteger(wxT("UI"), wxT("MainWindowWidth"), m_MainWindowWidth);
+	cfg.WriteInteger(wxT("UI"), wxT("MainWindowHeight"), m_MainWindowHeight);
 
 	m_Temperaments.Save(cfg);
 

--- a/src/grandorgue/GOrgueSettings.h
+++ b/src/grandorgue/GOrgueSettings.h
@@ -37,6 +37,7 @@
 #include "GOrgueSettingString.h"
 #include "GOrgueSoundPortsConfig.h"
 #include "ptrvector.h"
+#include <wx/gdicmn.h>
 #include <wx/string.h>
 #include <map>
 #include <vector>
@@ -85,6 +86,11 @@ private:
 	ptr_vector<GOrgueMidiReceiverBase> m_MIDIEvents;
 	GOrgueMidiMap m_MidiMap;
 	GOrgueTemperamentList m_Temperaments;
+	int m_MainWindowX;
+	int m_MainWindowY;
+	unsigned m_MainWindowWidth;
+	unsigned m_MainWindowHeight;
+	
 	static const GOMidiSetting m_MIDISettings[];
 	static const struct IniFileEnumEntry m_InitialLoadTypes[];
 
@@ -165,7 +171,7 @@ public:
 	GOrgueSettingDirectory AudioRecorderPath;
 	GOrgueSettingDirectory MidiRecorderPath;
 	GOrgueSettingDirectory MidiPlayerPath;
-
+	
 	void Load();
 
 	int GetLanguageId() const;
@@ -211,6 +217,9 @@ public:
 	GOrgueMidiMap& GetMidiMap();
 
 	GOrgueTemperamentList& GetTemperaments();
+	
+	wxRect GetMainWindowRect();
+	void SetMainWindowRect(const wxRect &rect);
 
 	void Flush();
 };

--- a/src/grandorgue/GOrgueSettings.h
+++ b/src/grandorgue/GOrgueSettings.h
@@ -204,6 +204,7 @@ public:
 	{ m_PortsConfig = portsConfig; }
 	
 	const std::vector<GOAudioDeviceConfig>& GetAudioDeviceConfig();
+	const unsigned GetTotalAudioChannels() const;
 	void SetAudioDeviceConfig(const std::vector<GOAudioDeviceConfig>& config);
 	unsigned GetDefaultLatency();
 

--- a/src/grandorgue/GrandOrgueFrame.cpp
+++ b/src/grandorgue/GrandOrgueFrame.cpp
@@ -267,9 +267,7 @@ GOrgueFrame::GOrgueFrame(wxFrame *frame, wxWindowID id, const wxString& title, c
 	
 	UpdateSize();
 	
-	int nr = wxDisplay::GetFromWindow(this);
-	wxDisplay display(nr != wxNOT_FOUND ? nr : 0);
-	Move(display.GetClientArea().GetPosition().x + 1, display.GetClientArea().GetPosition().y + 1);
+	ApplyRectFromSettings(m_Settings.GetMainWindowRect());
 
 	m_listener.Register(&m_Sound.GetMidi());
 	m_isMeterReady = true;
@@ -333,8 +331,27 @@ void GOrgueFrame::UpdateSize()
   
   const wxSize frameSize(GetSize());
   
-  SetMinSize(wxSize(frameSize.GetWidth() / 2, frameSize.GetHeight()));
-  SetMaxSize(wxSize(frameSize.GetWidth() * 2, frameSize.GetHeight()));
+  SetMinSize(wxSize(frameSize.GetWidth() / 4, frameSize.GetHeight()));
+  SetMaxSize(wxSize(frameSize.GetWidth() * 4, frameSize.GetHeight()));
+}
+
+void GOrgueFrame::ApplyRectFromSettings(wxRect rect)
+{
+  if (rect.width && rect.height)
+  { // settings are valid
+    wxRect minSize(GetMinSize());
+    wxRect maxSize(GetMaxSize());
+    
+    if (rect.width < minSize.width)
+      rect.width = minSize.width;
+    if (rect.width > maxSize.width)
+      rect.width = maxSize.width;
+    if (rect.height < minSize.height)
+      rect.height = minSize.height;
+    if (rect.height > maxSize.height)
+      rect.height = maxSize.height;
+    SetSize(rect);
+  }
 }
 
 void GOrgueFrame::UpdateVolumeControlWithSettings()
@@ -863,6 +880,7 @@ void GOrgueFrame::OnAudioSettings(wxCommandEvent& WXUNUSED(event))
 		manager.RegisterPackageDirectory(m_Settings.OrganPackagePath());
 
 		UpdateVolumeControlWithSettings();
+		m_Settings.SetMainWindowRect(GetRect());
 		m_Sound.ResetSound(true);
 		m_Settings.Flush();
 	}

--- a/src/grandorgue/GrandOrgueFrame.cpp
+++ b/src/grandorgue/GrandOrgueFrame.cpp
@@ -144,7 +144,8 @@ GOrgueFrame::GOrgueFrame(wxFrame *frame, wxWindowID id, const wxString& title, c
 	m_listener(),
 	m_Title(title),
 	m_Label(),
-	m_MidiMonitor(false)
+	m_MidiMonitor(false),
+	m_isMeterReady(false)
 {
 	wxIcon icon;
 	icon.CopyFromBitmap(GetImage_GOIcon());
@@ -271,10 +272,12 @@ GOrgueFrame::GOrgueFrame(wxFrame *frame, wxWindowID id, const wxString& title, c
 	Move(display.GetClientArea().GetPosition().x + 1, display.GetClientArea().GetPosition().y + 1);
 
 	m_listener.Register(&m_Sound.GetMidi());
+	m_isMeterReady = true;
 }
 
 GOrgueFrame::~GOrgueFrame()
 {
+	m_isMeterReady = false;
 	if (m_doc) {
 	  delete m_doc;
 	  m_doc = NULL;
@@ -336,8 +339,10 @@ void GOrgueFrame::UpdateSize()
 
 void GOrgueFrame::UpdateVolumeControlWithSettings()
 {
+  m_isMeterReady = false;
   if (AdjustVolumeControlWithSettings())
     UpdateSize();
+  m_isMeterReady = true;
 }
 
 void GOrgueFrame::Init(wxString filename)
@@ -554,6 +559,7 @@ void GOrgueFrame::OnSize(wxSizeEvent& event)
 
 void GOrgueFrame::OnMeters(wxCommandEvent& event)
 {
+  if (m_isMeterReady) {
 	const std::vector<double> vals = m_Sound.GetEngine().GetMeterInfo();
 	if (vals.size() == m_VolumeGauge.size() + 1)
 	{
@@ -567,6 +573,7 @@ void GOrgueFrame::OnMeters(wxCommandEvent& event)
 		  m_SamplerUsage->ResetClip();
 	  }
 	}
+  }
 }
 
 void GOrgueFrame::OnUpdateLoaded(wxUpdateUIEvent& event)

--- a/src/grandorgue/GrandOrgueFrame.h
+++ b/src/grandorgue/GrandOrgueFrame.h
@@ -150,7 +150,7 @@ private:
 
 public:
 	GOrgueFrame(wxFrame *frame, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, const long type, GOrgueSound& sound);
-	~GOrgueFrame(void);
+	virtual ~GOrgueFrame(void);
 
 	void Init(wxString filename);
 	bool Close();
@@ -159,6 +159,8 @@ public:
 
 	void SendLoadFile(wxString filename);
 
+	void ApplyRectFromSettings(wxRect rect);
+	
 	DECLARE_EVENT_TABLE()
 };
 

--- a/src/grandorgue/GrandOrgueFrame.h
+++ b/src/grandorgue/GrandOrgueFrame.h
@@ -66,6 +66,7 @@ private:
 	wxString m_Title;
 	wxString m_Label;
 	bool m_MidiMonitor;
+	bool m_isMeterReady;
 
 	void InitHelp();
 	void UpdatePanelMenu();

--- a/src/grandorgue/GrandOrgueFrame.h
+++ b/src/grandorgue/GrandOrgueFrame.h
@@ -72,7 +72,9 @@ private:
 	void UpdateFavoritesMenu();
 	void UpdateRecentMenu();
 	void UpdateTemperamentMenu();
-	void UpdateVolumeControl(unsigned count);
+	bool AdjustVolumeControlWithSettings();
+	void UpdateSize();
+	void UpdateVolumeControlWithSettings();
 
 	GOrgueDocument* GetDocument();
 


### PR DESCRIPTION
Resolves: #68
Resolves: #71 
Resolves: #72

- Now the main window size is set correctly if it was not saved with the organ settings #71
- The main window can be resized manually and it's size and position is stored by `Save` menu entry
- If there are no organ open then the size and the position is saved on exit from the Setting dialog
- There is still a problem with sizing in MacOs #72 caused a wxWidget/Osx bug. But now there is a workaround: enlarge this window manually and save the new size
- Refactored working with audio meters; the old one caused a crash on OSx when exit #68